### PR TITLE
Add pinned requirements and offline wheel support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy==1.26.4
+scipy==1.11.4
+pandas==2.2.2
+scikit-learn==1.4.2
+watchdog==4.0.0
+PyYAML==6.0.1

--- a/scripts/00_install_deps.sh
+++ b/scripts/00_install_deps.sh
@@ -16,7 +16,30 @@ sys.exit(0 if marker.exists() else 1)
 PY
   echo "Detected PEP 668 EXTERNALLY-MANAGED; using --user install" >&2
 fi
-${PYTHON} -m pip install "${PIP_FLAGS[@]}" numpy scipy pandas scikit-learn watchdog pyyaml >/dev/null
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REQ_FILE="${SCRIPT_DIR}/../requirements.txt"
+
+WHEEL_DIR_ENV=${WHEEL_DIR:-}
+WHEEL_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --wheel-dir)
+      WHEEL_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--wheel-dir DIR]" >&2
+      exit 1
+      ;;
+  esac
+done
+WHEEL_DIR=${WHEEL_DIR:-$WHEEL_DIR_ENV}
+if [[ -n "${WHEEL_DIR}" ]]; then
+  PIP_FLAGS+=(--no-index --find-links "$WHEEL_DIR")
+fi
+
+${PYTHON} -m pip install "${PIP_FLAGS[@]}" -r "$REQ_FILE" >/dev/null
 
 echo "Kernel: $(uname -r)"
 if lsmod | grep -q iwlwifi; then


### PR DESCRIPTION
## Summary
- pin Python dependencies in new `requirements.txt`
- make install script read the requirement file and support `--wheel-dir` for offline installs

## Testing
- `bash -n scripts/00_install_deps.sh`
- `./scripts/00_install_deps.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0dc2625e48328908a209c657f1b1c