### PR TITLE
Validate baseline dimensions before subtraction

### DIFF
--- a/csi_node/pipeline.py
+++ b/csi_node/pipeline.py
@@ -90,6 +90,12 @@ def compute_window(buffer, start_ts, end_ts, baseline, cfg):
 
     amps = np.stack([p["csi"] for p in valid], axis=0)
     if baseline is not None:
+        if baseline.shape != amps.shape[1:]:
+            msg = (
+                f"Baseline shape {baseline.shape} does not match "
+                f"amplitude shape {amps.shape[1:]}"
+            )
+            raise ValueError(msg)
         amps = amps - baseline
     amps = amps.reshape(amps.shape[0], -1)
     var = float(np.var(amps))


### PR DESCRIPTION
## Summary
- Ensure baseline shape matches stacked amplitudes before subtraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0dc2368a8832891e89c1a86dd2d15