### PR TITLE
Log FeitCSI output and propagate exit code

### DIFF
--- a/scripts/10_csi_capture.sh
+++ b/scripts/10_csi_capture.sh
@@ -26,9 +26,15 @@ WIDTH=${2:-80}
 CODING=${3:-${FEITCSI_CODING:-BCC}}
 CODING=${CODING^^}
 LOG=./data/csi_raw.log
+STDLOG=./data/feitcsi.log
 
 mkdir -p ./data
 
 freq=$(channel_to_freq "$CHANNEL")
-echo "Starting FeitCSI capture on channel $CHANNEL (${freq} MHz) width $WIDTH MHz coding $CODING"
-$FEITCSI_BIN -f "$freq" -w "$WIDTH" --coding "$CODING" -o "$LOG"
+echo "Starting FeitCSI capture on channel $CHANNEL (${freq} MHz) width $WIDTH MHz coding $CODING" | tee -a "$STDLOG"
+
+set +e
+$FEITCSI_BIN -f "$freq" -w "$WIDTH" --coding "$CODING" -o "$LOG" 2>&1 | tee -a "$STDLOG"
+exit_code=${PIPESTATUS[0]}
+set -e
+exit $exit_code


### PR DESCRIPTION
## Summary
- Log FeitCSI stdout/stderr via tee so messages are shown and saved
- Propagate FeitCSI's exit code to calling shell

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0f1aa89bc8328a1f03d35ad61b4a7