### PR TITLE
Verify CSI log creation and report FeitCSI errors

### DIFF
--- a/scripts/10_csi_capture.sh
+++ b/scripts/10_csi_capture.sh
@@ -31,4 +31,20 @@ mkdir -p ./data
 
 freq=$(channel_to_freq "$CHANNEL")
 echo "Starting FeitCSI capture on channel $CHANNEL (${freq} MHz) width $WIDTH MHz coding $CODING"
-$FEITCSI_BIN -f "$freq" -w "$WIDTH" --coding "$CODING" -o "$LOG"
+tmp_err=$(mktemp)
+$FEITCSI_BIN -f "$freq" -w "$WIDTH" --coding "$CODING" -o "$LOG" 2> >(tee "$tmp_err" >&2) &
+FEITCSI_PID=$!
+sleep 1
+if [[ ! -s "$LOG" ]]; then
+  echo "FeitCSI failed: $LOG not created or empty" >&2
+  if [[ -s "$tmp_err" ]]; then
+    echo "--- FeitCSI stderr ---" >&2
+    cat "$tmp_err" >&2
+  fi
+  kill "$FEITCSI_PID" 2>/dev/null || true
+  wait "$FEITCSI_PID" 2>/dev/null || true
+  rm -f "$tmp_err"
+  exit 1
+fi
+rm -f "$tmp_err"
+wait "$FEITCSI_PID"


### PR DESCRIPTION
## Summary
- Ensure FeitCSI capture waits briefly then checks `data/csi_raw.log`
- Show FeitCSI stderr and exit cleanly if log is missing or empty

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0f1aa9ae08328aa842afdbe161ca7