### PR TITLE
feat(gui,capture): add .dat capture path + streaming converter; improve pre/postflight and passwordless sudo

### DIFF
--- a/scripts/setup_passwordless.sh
+++ b/scripts/setup_passwordless.sh
@@ -20,7 +20,7 @@ resolve() {
     # Fallback to common locations
     case "$cmd" in
       rfkill|modprobe|setcap|iw|ip) echo "/usr/sbin/$cmd" ;;
-      systemctl|mount|ln) echo "/usr/bin/$cmd" ;;
+      systemctl|mount|ln|nmcli) echo "/usr/bin/$cmd" ;;
       *) echo "$cmd" ;;
     esac
   fi
@@ -34,9 +34,10 @@ IP=$(resolve ip)
 SYSTEMCTL=$(resolve systemctl)
 MOUNT=$(resolve mount)
 LN=$(resolve ln)
+NMCLI=$(resolve nmcli)
 FEITCSI=${FEITCSI_BIN:-/usr/local/bin/feitcsi}
 
-CONTENT="${USER_NAME} ALL=(root) NOPASSWD: ${RFKILL}, ${MODPROBE}, ${SETCAP}, ${IW}, ${IP}, ${SYSTEMCTL}, ${MOUNT}, ${LN}, ${FEITCSI}"
+CONTENT="${USER_NAME} ALL=(root) NOPASSWD: ${RFKILL}, ${MODPROBE}, ${SETCAP}, ${IW}, ${IP}, ${SYSTEMCTL}, ${MOUNT}, ${LN}, ${NMCLI}, ${FEITCSI}"
 
 # Must be root to write sudoers; if not, re-exec via pkexec or sudo
 if [[ $EUID -ne 0 ]]; then


### PR DESCRIPTION
GUI: add “Dat mode” to run .dat→JSONL pipeline and TUI; safer debugfs checks; cleanup lingering FeitCSI ifaces.
Capture: scripts/10_csi_capture.sh now writes .dat and streams to JSONL via scripts/dat2json_stream.py; clearer logging and fallbacks.
Sudo: scripts/setup_passwordless.sh includes nmcli in allowed commands.
Stability: improved start/stop and diagnostics, consistent logs.
Files touched: csi_node/gui.py, scripts/10_csi_capture.sh, scripts/setup_passwordless.sh.
Tested on AX210/Kali; JSONL and presence log rotate as configured.